### PR TITLE
Facilitating for Cuda builds

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -40,8 +40,6 @@ RUN INSTALL_PKGS="rh-python36 rh-python36-python-devel rh-python36-python-setupt
     yum install -y centos-release-scl && \
     yum -y --setopt=tsflags=nodocs install --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    # Remove centos-logos (httpd dependency) to keep image size smaller.
-    rpm -e --nodeps centos-logos && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.


### PR DESCRIPTION
Facilitating for Cuda builds
removing centos-logos causes installing dependencies issues with s2i-base-centos7 base.

Related-to: https://github.com/thoth-station/tensorflow-build-s2i/issues/40

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>